### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ traP 2023春合宿記念 オリジナルISUCON
 ## 遊び方 (08/26時点)
 
 1. 手元でもどこかのサーバーでも良いので、GoとMySQLがインストールされたLinux環境を用意する
+   - `qrencode`コマンドが必要です。Ubuntu/Debianの場合は`sudo apt install qrencode`でインストールできます
 2. MySQLにパスワード「isucon」で「isucon」という名前のユーザーを作り、「isulibrary」という名前でデータベースを用意する
 3. リポジトリを任意の場所にクローンする
 4. <https://github.com/logica0419/gasshuku-isucon/releases/tag/initial-data> から
    1. `1_data.sql`をダウンロードし`webapp/sql`内に置く
-   2. `init_data.json`をダウンロードし`bench/repository`内に置く
+   2. `webapp/sql/init_db.sh` を実行してデータベースを初期化する
+   3. `init_data.json`をダウンロードし`bench/repository`内に置く
 5. `make run-go`を実行するなどの方法で、`webapp/go/main.go`を恒常的に立ち上げた状態にする
 6. `make run-bench`を実行するなどの方法で、`bench/main.go`を実行してベンチマークを開始する


### PR DESCRIPTION
Add descriptions for the initial setup.
- qrencode command is required.
- Do init_db.sh to import initial data.

初期化からベンチマーク完走までに不足していた手順をREADMEに追加しました。